### PR TITLE
add role for installing Zend Guard (zend-loader-php5.5)

### DIFF
--- a/ansible/roles/common/meta/main.yml
+++ b/ansible/roles/common/meta/main.yml
@@ -6,5 +6,6 @@ dependencies:
   - php
   - mailhog
   - xdebug
+  - zendguard  
   - composer
   - varnish

--- a/ansible/roles/zendguard/tasks/install.yml
+++ b/ansible/roles/zendguard/tasks/install.yml
@@ -1,0 +1,31 @@
+---
+- stat: path=/usr/lib/php5/20121212/zend-loader-php5.5-linux-x86_64.tar.gz
+  register: zendGuardArchive
+
+- name: Download the ZendGuard shared object files
+  become: yes
+  get_url: url="https://github.com/OXID-eSales/oxvm_assets/blob/master/zend-loader-php5.5-linux-x86_64.tar.gz?raw=true" dest="/usr/lib/php5/20121212/"
+  when: zendGuardArchive.stat.exists == False
+
+- unarchive: src=/usr/lib/php5/20121212/zend-loader-php5.5-linux-x86_64.tar.gz dest=/usr/lib/php5/20121212/
+  become: yes
+
+- copy: src=/usr/lib/php5/20121212/zend-loader-php5.5-linux-x86_64/ZendGuardLoader.so dest=/usr/lib/php5/20121212/ZendGuardLoader.so
+  become: yes
+
+- copy: src=/usr/lib/php5/20121212/zend-loader-php5.5-linux-x86_64/opcache.so dest=/usr/lib/php5/20121212/zend_opcache.so
+  become: yes
+
+- name: Place ZendGuard configuration
+  become: yes
+  template: src=zend.ini dest=/etc/php5/mods-available/zend.ini
+
+- name: Disable standard PHP5 opcache
+  become: yes
+  command: php5dismod opcache
+  notify: restart apache
+
+- name: Enable ZendGuard opcache
+  become: yes
+  command: php5enmod zend
+  notify: restart apache

--- a/ansible/roles/zendguard/tasks/main.yml
+++ b/ansible/roles/zendguard/tasks/main.yml
@@ -1,0 +1,3 @@
+---
+- include: install.yml
+  when: php.zendguard.install

--- a/ansible/roles/zendguard/templates/zend.ini
+++ b/ansible/roles/zendguard/templates/zend.ini
@@ -1,0 +1,2 @@
+zend_extension=ZendGuardLoader.so
+zend_extension=zend_opcache.so

--- a/ansible/vars/default.yml
+++ b/ansible/vars/default.yml
@@ -66,6 +66,8 @@ php:
     prestissimo:
       install: false
   pecl_packages: ~
+  zendguard:
+    install: false
 mailhog:
   install: false
   web_port: 8025


### PR DESCRIPTION
This role adds the zend-loader-php5.5 like described on 
https://github.com/OXID-eSales/oxvm_eshop#browser-shows-zend-guard-run-time-support-missing (install: false by default) It is not generic for different PHP-versions yet as it is questionable if this makes sense and how to meet this target.