### PR TITLE
Fix ansible deprecation notices

### DIFF
--- a/ansible/roles/apache/tasks/install.yml
+++ b/ansible/roles/apache/tasks/install.yml
@@ -19,14 +19,14 @@
   apache2_module: state=absent name={{ item }}
   when: not mailhog.install
   notify: restart apache
-  with_items: mailhog.apache_modules|reverse|list
+  with_items: "{{ mailhog.apache_modules|reverse|list }}"
 
 - name: Install Apache Modules for mailhog
   become: yes
   apache2_module: state=present name={{ item }}
   when: mailhog.install
   notify: restart apache
-  with_items: mailhog.apache_modules
+  with_items: "{{ mailhog.apache_modules }}"
 
 - shell: apache2 -v
   register: apache_version

--- a/ansible/roles/php/tasks/install.yml
+++ b/ansible/roles/php/tasks/install.yml
@@ -16,7 +16,7 @@
 - name: Install PHP Packages
   become: yes
   apt: pkg={{ item }} state=latest
-  with_items: php.packages
+  with_items: "{{ php.packages }}"
   when: php.packages is defined
   notify:
     - restart apache

--- a/ansible/roles/php/tasks/pecl.yml
+++ b/ansible/roles/php/tasks/pecl.yml
@@ -9,7 +9,7 @@
   register: pecl_result
   changed_when: "'already installed' not in pecl_result.stdout"
   failed_when: "pecl_result.stderr or ('ERROR' in pecl_result.stdout)"
-  with_items: php.pecl_packages
+  with_items: "{{ php.pecl_packages }}"
   when: php.pecl_packages
 
 - name: Create extension .ini file
@@ -20,11 +20,11 @@
     owner="root"
     group="root"
     mode=0644
-  with_items: php.pecl_packages
+  with_items: "{{ php.pecl_packages }}"
   when: php.pecl_packages
 
 - name: Enable extension
   become: yes
   shell: php5enmod {{ item }}
-  with_items: php.pecl_packages
+  with_items: "{{ php.pecl_packages }}"
   when: php.pecl_packages

--- a/ansible/roles/server/tasks/main.yml
+++ b/ansible/roles/server/tasks/main.yml
@@ -41,13 +41,13 @@
 - name: Install Extra Packages
   become: yes
   apt: pkg={{ item }} state=latest
-  with_items: server.packages
+  with_items: "{{ server.packages }}"
   when: server.packages
 
 - name: Install Extra personal Packages
   become: yes
   apt: pkg={{ item }} state=latest
-  with_items: server.personal_packages
+  with_items: "{{ server.personal_packages }}"
   when: server.personal_packages
 
 - name: Configure the timezone


### PR DESCRIPTION
Ansible requires that variables are explicitly declared with {{ }} and surrounded with quotes.

More information: https://docs.ansible.com/ansible/porting_guide_2.0.html