### PR TITLE
Use extra mounting options only for Windows

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## [1.1.3] - 2018-07-12
+
+### Changed
+- Change permissions of `/vagrant` share only for Windows ([ansible issue](https://github.com/ansible/ansible/issues/42388))
+
 ## [1.1.2] - 2018-07-11
 
 ### Changed
@@ -25,6 +30,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - README now contains configuration information
 - Varnish setup information
 
+[1.1.3]: https://github.com/OXID-eSales/oxvm_base/compare/v1.1.2...v1.1.3
 [1.1.2]: https://github.com/OXID-eSales/oxvm_base/compare/v1.1.1...v1.1.2
 [1.1.1]: https://github.com/OXID-eSales/oxvm_base/compare/v1.1.0...v1.1.1
 [1.1.0]: https://github.com/OXID-eSales/oxvm_base/compare/v1.0.0...v1.1.0

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -71,7 +71,7 @@ def override_network(override, vm_config, provider)
 end
 
 Vagrant.configure("2") do |config|
-  config.vm.synced_folder ".", "/vagrant", mount_options:  ["dmode=775,fmode=664"]
+  config.vm.synced_folder ".", "/vagrant", mount_options:  ["dmode=775,fmode=664"] if Vagrant::Util::Platform.windows?
   if defined? config_hook
     config_hook.each do |f|
       f.call(config, vm_config)


### PR DESCRIPTION
This is needed as not all platforms support and/or accept the given
parameters and sometimes one could get the following message which
would prevent from the VM to start at all, e.g.:

```
Failed to mount folders in Linux guest. You've specified mount options
which are not supported by "prl_fs" file system.

Invalid mount options: ["dmode=775,fmode=664"]
```

Also the original issue only seems to affect Windows platform with
virtualbox as hypervisor, as this can be seen at:

https://github.com/ansible/ansible/issues/42388