### PR TITLE
fix ansible detection

### DIFF
--- a/ansible/ruby/get_ansible_version.rb
+++ b/ansible/ruby/get_ansible_version.rb
@@ -1,6 +1,6 @@
 def get_ansible_version
   output = `ansible --version`
-  re = /ansible ([\d\.]+)/
+  re = /ansible .*?([\d\.]+)/
 
   match = output.match re
   version = match[1]


### PR DESCRIPTION
my ansible 4 output is like this:
```
ansible [core 2.11.2] 
  config file = /home/keywan/git/Bieber_und_Marburg/ansible.cfg
  configured module search path = ['/home/keywan/git/Bieber_und_Marburg/base_vm/ansible/library', '/home/keywan/git/Bieber_und_Marburg/ansible/library']
  ansible python module location = /home/keywan/.local/lib/python3.8/site-packages/ansible
  ansible collection location = /home/keywan/.ansible/collections:/usr/share/ansible/collections
  executable location = /home/keywan/.local/bin/ansible
  python version = 3.8.5 (default, May 27 2021, 13:30:53) [GCC 9.3.0]
  jinja version = 3.0.1
  libyaml = True
```
it looks like the code is not aware of the brackets `[` around the version number, so I guess older ansible versions did not have had that. The 
expresion 
```
.*?
``` I added should make sure that unknown characters in front of the version string will be ignored. that ways this should work for old and new versions of ansible